### PR TITLE
Remove undefined macro __THROW

### DIFF
--- a/include/libbb.h
+++ b/include/libbb.h
@@ -496,9 +496,9 @@ char *xrealloc_getcwd_or_warn(char *cwd) FAST_FUNC;
 char *xmalloc_follow_symlinks(const char *path) FAST_FUNC RETURNS_MALLOC;
 
 extern size_t strlcat(char *__restrict dst, const char *__restrict src,
-	size_t n) __THROW __nonnull ((1, 2));
+	size_t n);
 extern size_t strlcpy(char *__restrict dst, const char *__restrict src,
-	size_t n) __THROW __nonnull ((1, 2));
+	size_t n);
 
 enum {
 	/* bb_signals(BB_FATAL_SIGS, handler) catches all signals which


### PR DESCRIPTION
Macro `__THROW` is not defined in musl libc. Removing it make compilation under it not fail anymore.