### PR TITLE
Fix compatibility with 64bit time_t and compilation with GCC11 & musl

### DIFF
--- a/Makefile.flags
+++ b/Makefile.flags
@@ -124,6 +124,12 @@ CFLAGS += --sysroot=$(CONFIG_SYSROOT)
 export SYSROOT=$(CONFIG_SYSROOT)
 endif
 
+# glibc versions before 2.17 need to link with -rt to use clock_gettime
+RT_NEEDED := $(shell echo 'int main(void){struct timespec tp; return clock_gettime(CLOCK_MONOTONIC, &tp);}' >rttest.c; $(CC) $(CFLAGS) -include time.h -o /dev/null rttest.c >/dev/null 2>&1 || echo "y"; rm rttest.c)
+ifeq ($(RT_NEEDED),y)
+LDLIBS += rt
+endif
+
 # Android has no separate crypt library
 # gcc-4.2.1 fails if we try to feed C source on stdin:
 #  echo 'int main(void){return 0;}' | $(CC) $(CFLAGS) -lcrypt -o /dev/null -xc -

--- a/coreutils/date.c
+++ b/coreutils/date.c
@@ -37,7 +37,7 @@
 //config:config FEATURE_DATE_NANO
 //config:	bool "Support %[num]N nanosecond format specifier"
 //config:	default n
-//config:	depends on DATE  # syscall(__NR_clock_gettime)
+//config:	depends on DATE  # clock_gettime()
 //config:	select PLATFORM_LINUX
 //config:	help
 //config:	  Support %[num]N format specifier. Adds ~250 bytes of code.
@@ -265,9 +265,7 @@ int date_main(int argc UNUSED_PARAM, char **argv)
 #endif
 	} else {
 #if ENABLE_FEATURE_DATE_NANO
-		/* libc has incredibly messy way of doing this,
-		 * typically requiring -lrt. We just skip all this mess */
-		syscall(__NR_clock_gettime, CLOCK_REALTIME, &ts);
+		clock_gettime(CLOCK_REALTIME, &ts);
 #else
 		time(&ts.tv_sec);
 #endif

--- a/libbb/time.c
+++ b/libbb/time.c
@@ -243,7 +243,7 @@ char* FAST_FUNC strftime_YYYYMMDDHHMMSS(char *buf, unsigned len, time_t *tp)
  * typically requiring -lrt. We just skip all this mess */
 static void get_mono(struct timespec *ts)
 {
-	if (syscall(__NR_clock_gettime, CLOCK_MONOTONIC, ts))
+	if (clock_gettime(CLOCK_MONOTONIC, ts))
 		bb_error_msg_and_die("clock_gettime(MONOTONIC) failed");
 }
 unsigned long long FAST_FUNC monotonic_ns(void)


### PR DESCRIPTION
These two commits fix compilation with gcc 11 and musl, adding compatibility with 64-bit time_t as well.  gcc11 does not define the generic `__NR_clock_gettime` any longer.  Using `clock_gettime` is more portable, and the problem with needing librt is handled in `Makefile.flags`.

I have compile tested on gentoo x86_64 (64bit), and openwrt master, for mips32 (ath79).
I have run the `date` applet as a simple way to run-test the change.
* x86_64 using 64-bit time_t (glibc 2.33, gcc 10.3.0), 
* mips32 using 32-bit time_t (musl 1.1.24, gcc 8.4 & gcc 11.2.0).
* mips32 using 64-bit time_t (musl 1.2.2, gcc 11.2.0).