### PR TITLE
Fix receiving ICMPv6 echo replies on systems with a 32-bit pid_t

### DIFF
--- a/eperd/ping.c
+++ b/eperd/ping.c
@@ -1077,7 +1077,7 @@ static void ready_callback6 (int __attribute((unused)) unused,
 	/* Check the ICMP header to drop unexpected packets due to
 	 * unrecognized id
 	 */
-	if (icmp->icmp6_id != base->pid)
+	if (icmp->icmp6_id != (base->pid & 0xffff))
 	  {
 	    goto done;
 	  }


### PR DESCRIPTION
When an ICMPv6 echo request is sent, the ID field is set to the pid. 32-bit pids are explicitly truncated to 16 bits.

However, the same truncation is not performed when the ID field is checked against the pid when receiving a reply. This causes all replies to be ignored if the pid of the current process is greater than 65535.

This commit fixes the problem by truncating the pid in the code for receiving a reply too.