### PR TITLE
perd: make command run less verbose

### DIFF
--- a/miscutils/perd.c
+++ b/miscutils/perd.c
@@ -874,7 +874,7 @@ static void RunJobs(void)
 			kick_watchdog();
 
 			RunJob(file->cf_User, line);
-			crondlog(LVL8 "USER %s pid %3d cmd %s",
+			crondlog(LVL7 "USER %s pid %3d cmd %s",
 				file->cf_User, (int)line->cl_Pid, line->cl_Shell);
 			if (line->cl_Pid < 0) {
 				file->cf_Ready = 1;


### PR DESCRIPTION
The default log level is 8. We currently run each perd job and log their execution with log level 8. This seems to be an info log and including it in the error level seems wrong and probably an oversight when the code was implemented.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>