### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# top-most EditorConfig file
+root = true
+
+[*.{c,h}]
+indent_style = tab
+indent_size = 8

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 #
 # Kbuild ignores
+.config.old
+.kconfig.d
+.kernelrelease
+.*.cmd
 #
-.*
 *.o
 *.o.*
 *.a


### PR DESCRIPTION
.editorconfig is a standard, cross-editor format that enables automated application of simple file format standards.

    https://editorconfig.org/

Applying this change should make it easier to ensure that multiple people can contribute to the source without arbitrary editor defaults creating an accidental edit war.

Note that i adjusted the .gitignore file to permit inclusion of the .editorconfig while still excluding some of the Kbuild byproducts