### PR TITLE
applets/usage_pod.c: use format string for printf

### DIFF
--- a/applets/usage_pod.c
+++ b/applets/usage_pod.c
@@ -71,7 +71,7 @@ int main(void)
 		} else {
 			printf(", ");
 		}
-		printf(usage_array[i].aname);
+		printf("%s", usage_array[i].aname);
 		col += len2;
 	}
 	printf("\n\n");


### PR DESCRIPTION
Piping a string without formating to printf isn't
considered good practice.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security